### PR TITLE
[FEAT] 사이즈 및 레이아웃 관련 토큰 구현

### DIFF
--- a/lib/design_system/font/app_text_style.dart
+++ b/lib/design_system/font/app_text_style.dart
@@ -4,7 +4,7 @@ abstract class AppTextStyle {
   /// Pretendard
   static const pretendard = 'Pretendard';
 
-  static const titleL  = TextStyle(
+  static const titleL = TextStyle(
     fontFamily: pretendard,
     fontSize: 24,
     fontWeight: FontWeight.w600,
@@ -12,7 +12,7 @@ abstract class AppTextStyle {
     letterSpacing: -0.72,
   );
 
-  static const titleM  = TextStyle(
+  static const titleM = TextStyle(
     fontFamily: pretendard,
     fontSize: 20,
     fontWeight: FontWeight.w600,
@@ -20,7 +20,7 @@ abstract class AppTextStyle {
     letterSpacing: -0.60,
   );
 
-  static const titleS  = TextStyle(
+  static const titleS = TextStyle(
     fontFamily: pretendard,
     fontSize: 18,
     fontWeight: FontWeight.w600,
@@ -36,7 +36,7 @@ abstract class AppTextStyle {
     letterSpacing: -0.32,
   );
 
-  static const textLr  = TextStyle(
+  static const textLr = TextStyle(
     fontFamily: pretendard,
     fontSize: 16,
     fontWeight: FontWeight.w400,
@@ -52,7 +52,7 @@ abstract class AppTextStyle {
     letterSpacing: -0.28,
   );
 
-  static const textMm  = TextStyle(
+  static const textMm = TextStyle(
     fontFamily: pretendard,
     fontSize: 14,
     fontWeight: FontWeight.w500,
@@ -60,7 +60,7 @@ abstract class AppTextStyle {
     letterSpacing: -0.28,
   );
 
-  static const textMr  = TextStyle(
+  static const textMr = TextStyle(
     fontFamily: pretendard,
     fontSize: 14,
     fontWeight: FontWeight.w400,
@@ -68,7 +68,7 @@ abstract class AppTextStyle {
     letterSpacing: -0.28,
   );
 
-  static const textSm  = TextStyle(
+  static const textSm = TextStyle(
     fontFamily: pretendard,
     fontSize: 12,
     fontWeight: FontWeight.w500,
@@ -76,7 +76,7 @@ abstract class AppTextStyle {
     letterSpacing: -0.24,
   );
 
-  static const textSr  = TextStyle(
+  static const textSr = TextStyle(
     fontFamily: pretendard,
     fontSize: 12,
     fontWeight: FontWeight.w400,

--- a/lib/design_system/foundation/size/app_layout.dart
+++ b/lib/design_system/foundation/size/app_layout.dart
@@ -1,0 +1,27 @@
+part 'app_size.dart';
+
+/// App Layout (Margin & Padding, Stroke, Radius, etc)
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=485-18134&m=dev
+abstract final class AppLayout {
+  /// Margin & Padding
+  static const double marginPaddingXxs = _AppSize.spacingSize1;
+  static const double marginPaddingXs = _AppSize.spacingSize2;
+  static const double marginPaddingS = _AppSize.spacingSize3;
+  static const double marginPaddingM = _AppSize.spacingSize4;
+  static const double marginPaddingL = _AppSize.spacingSize5;
+  static const double marginPaddingXl = _AppSize.spacingSize6;
+  static const double marginPaddingXxl = _AppSize.spacingSize8;
+
+  /// Stroke
+  static const double stroke10 = 1.0;
+  static const double stroke15 = 1.5;
+  static const double stroke20 = 2.0;
+
+  /// Radius
+  static const double radius100 = _AppSize.spacingSize1;
+  static const double radius200 = _AppSize.spacingSize2;
+  static const double radius300 = _AppSize.spacingSize3;
+  static const double radius400 = _AppSize.spacingSize6;
+  static const double radius800 = _AppSize.spacingSize8;
+  static const double radius999 = _AppSize.spacingSize999;
+}

--- a/lib/design_system/foundation/size/app_size.dart
+++ b/lib/design_system/foundation/size/app_size.dart
@@ -1,0 +1,21 @@
+part of 'app_layout.dart';
+
+//ignore_for_file: unused_field
+
+/// Spacing & Size
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=485-18134&m=dev
+abstract final class _AppSize {
+  _AppSize._();
+
+  static const double spacingSize1 = 4;
+  static const double spacingSize2 = 8;
+  static const double spacingSize3 = 12;
+  static const double spacingSize4 = 16;
+  static const double spacingSize5 = 20;
+  static const double spacingSize6 = 24;
+  static const double spacingSize7 = 28;
+  static const double spacingSize8 = 32;
+  static const double spacingSize9 = 36;
+  static const double spacingSize10 = 40;
+  static const double spacingSize999 = 999;
+}


### PR DESCRIPTION
## 📌 관련 이슈
#14 
## ✨ 작업 내용
- 앱의 사이즈값과 레이아웃 값들을 정리하였습니다. `AppLayout`을 통해 사용할 수 있습니다.
- 앱의 사이즈값이 레이아웃 값을 설정할때만 사용될 것 같아서, 앱의 사이즈를 정리한 class를 private하게 선언하였습니다.
  ```dart
  abstract final class _AppSize {
    _AppSize._();
  
    static const double spacingSize1 = 4;
    static const double spacingSize2 = 8;
    static const double spacingSize3 = 12;
    static const double spacingSize4 = 16;
    ...
  }
  ```
## 📸 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 첨부해주세요. -->

## 📚 참고 자료
[Design System > Spacing & Size](https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=485-18134&m=dev)
