### PR TITLE
[FEAT] Tab (TabBar), Segment Control 추가

### DIFF
--- a/lib/design_system/component/app_segment_control.dart
+++ b/lib/design_system/component/app_segment_control.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/design_system/font/app_text_style.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+
+/// Segment Controll
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1399-26258&m=dev
+class AppSegmentControl extends StatelessWidget {
+  const AppSegmentControl({
+    required this.tabs,
+    required this.controller,
+    super.key,
+  });
+  final List<Tab> tabs;
+  final TabController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppLayout.radius300),
+        color: AppScaleColor.gray300,
+      ),
+      padding: const EdgeInsets.all(AppLayout.marginPaddingXxs),
+      child: TabBar(
+        controller: controller,
+        tabs: tabs,
+        indicator: BoxDecoration(
+          borderRadius: BorderRadius.circular(AppLayout.radius200),
+          color: AppScaleColor.white100,
+        ),
+        indicatorSize: TabBarIndicatorSize.tab,
+        indicatorColor: Colors.transparent,
+        dividerColor: Colors.transparent,
+        labelStyle: AppTextStyle.textLsb,
+        labelColor: AppScaleColor.gray700,
+        unselectedLabelStyle: AppTextStyle.textLsb,
+        unselectedLabelColor: AppScaleColor.gray500,
+        splashFactory: NoSplash.splashFactory,
+
+        /// 탭바 클릭시 나오는 splash effect 컬러
+        overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+      ),
+    );
+  }
+}

--- a/lib/design_system/component/app_segment_control.dart
+++ b/lib/design_system/component/app_segment_control.dart
@@ -5,13 +5,20 @@ import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
 
 /// Segment Controll
 /// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1399-26258&m=dev
+
+// Segment Item
+class SegmentItem {
+  const SegmentItem({required this.text});
+  final String text;
+}
+
 class AppSegmentControl extends StatelessWidget {
   const AppSegmentControl({
-    required this.tabs,
+    required this.items,
     required this.controller,
     super.key,
   });
-  final List<Tab> tabs;
+  final List<SegmentItem> items;
   final TabController controller;
 
   @override
@@ -24,11 +31,12 @@ class AppSegmentControl extends StatelessWidget {
       padding: const EdgeInsets.all(AppLayout.marginPaddingXxs),
       child: TabBar(
         controller: controller,
-        tabs: tabs,
+        tabs: items.map((e) => Tab(text: e.text, height: 48)).toList(),
         indicator: BoxDecoration(
           borderRadius: BorderRadius.circular(AppLayout.radius200),
           color: AppScaleColor.white100,
         ),
+        indicatorWeight: 0,
         indicatorSize: TabBarIndicatorSize.tab,
         indicatorColor: Colors.transparent,
         dividerColor: Colors.transparent,

--- a/lib/design_system/component/app_tab.dart
+++ b/lib/design_system/component/app_tab.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/design_system/font/app_text_style.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+
+/// Tab
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1399-26247&m=dev
+class AppTabBar extends StatelessWidget {
+  const AppTabBar({required this.tabs, required this.controller, super.key});
+  final List<Tab> tabs;
+  final TabController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 46,
+      child: TabBar(
+        controller: controller,
+        tabs: tabs,
+        indicatorSize: TabBarIndicatorSize.tab,
+        indicatorWeight: 2,
+        indicatorColor: AppScaleColor.gray700,
+        labelStyle: AppTextStyle.textLsb,
+        labelColor: AppScaleColor.gray700,
+        unselectedLabelStyle: AppTextStyle.textLsb,
+        unselectedLabelColor: AppScaleColor.gray500,
+        splashFactory: NoSplash.splashFactory,
+
+        /// 탭바 클릭시 나오는 splash effect 컬러
+        overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+      ),
+    );
+  }
+}

--- a/lib/design_system/component/app_tab.dart
+++ b/lib/design_system/component/app_tab.dart
@@ -4,30 +4,40 @@ import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
 
 /// Tab
 /// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1399-26247&m=dev
+
+// Tab Bar Item
+class TabBarItem {
+  const TabBarItem({required this.text});
+  final String text;
+}
+
 class AppTabBar extends StatelessWidget {
-  const AppTabBar({required this.tabs, required this.controller, super.key});
-  final List<Tab> tabs;
+  const AppTabBar({required this.items, required this.controller, super.key});
+  final List<TabBarItem> items;
   final TabController controller;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 46,
-      child: TabBar(
-        controller: controller,
-        tabs: tabs,
-        indicatorSize: TabBarIndicatorSize.tab,
-        indicatorWeight: 2,
-        indicatorColor: AppScaleColor.gray700,
-        labelStyle: AppTextStyle.textLsb,
-        labelColor: AppScaleColor.gray700,
-        unselectedLabelStyle: AppTextStyle.textLsb,
-        unselectedLabelColor: AppScaleColor.gray500,
-        splashFactory: NoSplash.splashFactory,
-
-        /// 탭바 클릭시 나오는 splash effect 컬러
-        overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+    return TabBar(
+      controller: controller,
+      tabs: items.map((e) => Tab(text: e.text, height: 46)).toList(),
+      indicatorSize: TabBarIndicatorSize.tab,
+      indicator: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: AppScaleColor.gray700, width: 2),
+        ),
       ),
+      indicatorWeight: 0,
+      indicatorPadding: EdgeInsets.zero,
+      indicatorColor: AppScaleColor.gray700,
+      labelStyle: AppTextStyle.textLsb,
+      labelColor: AppScaleColor.gray700,
+      unselectedLabelStyle: AppTextStyle.textLsb,
+      unselectedLabelColor: AppScaleColor.gray500,
+      splashFactory: NoSplash.splashFactory,
+
+      /// 탭바 클릭시 나오는 splash effect 컬러
+      overlayColor: const WidgetStatePropertyAll(Colors.transparent),
     );
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
#12 
## ✨ 작업 내용
Tab bar, Segment control을 추가합니다.
사용예시는 아래와 같습니다.

**TabBar**
```dart
AppTabBar(
  items: [
    const TabBarItem(text: '첫번째탭'),
    const TabBarItem(text: '두번째탭'),
    const TabBarItem(text: '세번째탭'),
  ],
  controller: _controller,
),
```
**Segment Control**
```dart
AppSegmentControl(
  items: [
    const SegmentItem(text: '첫번째탭'),
    const SegmentItem(text: '두번째탭'),
    const SegmentItem(text: '세번째탭'),
  ],
  controller: _controller,
),
```
item 필드에 필요한 아이템을 명시적으로 지정하고,
`TabController`를 생성해서 연동시켜주면 사용 가능합니다!

### 특이사항
TabBar나 Segment Control의 아이템 클릭 시, 별도의 splash effect가 발생하지 않도록 구현하였습니다.
splash effect가 필요하다면 추후에 구현하겠습니다~

## 📸 스크린샷 (선택)
| TabBar (첫번째탭 클릭) | TabBar(두번째탭 클릭) | Segment Control |
| -------------------- | --------------------- | ----------------- |
|  ![Simulator Screenshot - iPhone 16 - 2025-06-27 at 00 08 41](https://github.com/user-attachments/assets/a693240d-31dd-45b7-9b35-1cc522fa1a31) |  ![Simulator Screenshot - iPhone 16 - 2025-06-27 at 00 08 45](https://github.com/user-attachments/assets/bc6142e2-160f-4706-b3c2-3d81b8d65648) |  ![Simulator Screenshot - iPhone 16 - 2025-06-27 at 00 06 35](https://github.com/user-attachments/assets/5fdd2c94-4cbc-4455-ab56-dea4c1b830f4) |





## 📚 참고 자료
<!-- 참고한 가이드 문서나 레퍼런스 링크가 있다면 입력해주세요. -->

