### PR TITLE
[FEAT] Page Indicator 추가

### DIFF
--- a/lib/design_system/component/app_page_indicator.dart
+++ b/lib/design_system/component/app_page_indicator.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+/// Page Indicator (Dot)
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1399-27485&m=dev
+class AppPageIndicator extends StatelessWidget {
+  const AppPageIndicator({
+    required this.controller,
+    required this.count,
+    super.key,
+  });
+  final PageController controller;
+  final int count; // 페이지 개수
+
+  @override
+  Widget build(BuildContext context) {
+    return SmoothPageIndicator(
+      controller: controller,
+      count: count,
+
+      /// Slide Effect 적용
+      effect: const SlideEffect(
+        offset: 0,
+        dotWidth: 8,
+        dotHeight: 8,
+        spacing: 8,
+        strokeWidth: 0,
+        radius: AppLayout.radius100,
+        activeDotColor: AppScaleColor.orange500,
+        dotColor: AppScaleColor.gray400,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -925,6 +925,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  smooth_page_indicator:
+    dependency: "direct main"
+    description:
+      name: smooth_page_indicator
+      sha256: b21ebb8bc39cf72d11c7cfd809162a48c3800668ced1c9da3aade13a32cf6c1c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   cached_network_image: ^3.4.1
   flutter_gen: ^5.10.0
   lottie: ^3.3.1
+  smooth_page_indicator: ^1.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📌 관련 이슈
#12 
## ✨ 작업 내용
Page indicator를 추가하였습니다.
[smooth_page_indicator](https://pub.dev/packages/smooth_page_indicator)를 이용하여 구현하였습니다.
사용예시는 아래와 같습니다.
```dart
...
PageView(
  controller: controller,
  children: [
    Container(color: Colors.green),
    Container(color: Colors.blue),
    Container(color: Colors.orange),
  ],
),
...
Align(
  alignment: Alignment.bottomCenter,
  child: Padding(
    padding: const EdgeInsets.only(bottom: 60),
    /// Page Indicator에 Page Controller 연결
    child: AppPageIndicator(controller: controller, count: 3),
  ),
),
...
```
Page Indicator의 Effect는 가장 단순하고 직관적이라고 생각되는 **Slide Effect (built_in)** 를 적용하였습니다.

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/feb87317-c544-4d4c-b060-7861d2db1201



## 📚 참고 자료
<!-- 참고한 가이드 문서나 레퍼런스 링크가 있다면 입력해주세요. -->

