### PR TITLE
[FEAT] Snack Bar, Toast 추가

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
+  - fluttertoast (0.0.2):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -12,6 +14,7 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
 
@@ -20,6 +23,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  fluttertoast:
+    :path: ".symlinks/plugins/fluttertoast/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   sqflite_darwin:
@@ -28,6 +33,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
 

--- a/lib/app/di/config.dart
+++ b/lib/app/di/config.dart
@@ -1,14 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gllo_flutter/app/environment/environment.dart';
-import 'package:gllo_flutter/app/toast/toast_manager.dart';
 import 'package:gllo_flutter/core/network/app_dio.dart';
 
 /// configuration dependency 등록
 
 final appDioProvider = Provider((ref) {
   return AppDio(baseUrl: Environment.enviromentType.baseUrl).dio;
-});
-
-final toastManagerProvider = Provider((ref) {
-  return ToastManager();
 });

--- a/lib/app/di/config.dart
+++ b/lib/app/di/config.dart
@@ -1,9 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gllo_flutter/app/environment/environment.dart';
+import 'package:gllo_flutter/app/toast/toast_manager.dart';
 import 'package:gllo_flutter/core/network/app_dio.dart';
 
 /// configuration dependency 등록
 
 final appDioProvider = Provider((ref) {
   return AppDio(baseUrl: Environment.enviromentType.baseUrl).dio;
+});
+
+final toastManagerProvider = Provider((ref) {
+  return ToastManager();
 });

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -24,6 +24,7 @@ class AppRouter {
 
   late final GoRouter routerConfig = GoRouter(
     initialLocation: Routes.home.name,
+    navigatorKey: rootNavigatorKey,
     routes: [
       /// 샘플 화면
       GoRoute(

--- a/lib/app/toast/toast_manager.dart
+++ b/lib/app/toast/toast_manager.dart
@@ -5,6 +5,11 @@ import 'package:gllo_flutter/app/router/app_router.dart';
 /// fluttertoast를 이용하여 Toast 관리
 /// 앱의 Snack Bar와 Toast를 표시할때 사용
 class ToastManager {
+  factory ToastManager() => instance;
+  ToastManager._();
+
+  static ToastManager instance = ToastManager._();
+
   final _fToast = FToast();
 
   bool _isInitialized = false;

--- a/lib/app/toast/toast_manager.dart
+++ b/lib/app/toast/toast_manager.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:gllo_flutter/app/router/app_router.dart';
+
+/// fluttertoast를 이용하여 Toast 관리
+/// 앱의 Snack Bar와 Toast를 표시할때 사용
+class ToastManager {
+  final _fToast = FToast();
+
+  bool _isInitialized = false;
+
+  /// fluttertoast 초기화
+  void _init() {
+    if (!_isInitialized) {
+      _fToast.init(AppRouter.rootNavigatorKey.currentContext!);
+      _isInitialized = true;
+    }
+  }
+
+  /// fluttertoast 표시
+  void show({required Widget toastWidget}) {
+    if (!_isInitialized) {
+      _init();
+    }
+
+    _fToast.removeCustomToast();
+
+    _fToast.showToast(
+      child: toastWidget,
+      toastDuration: const Duration(seconds: 3),
+      positionedToastBuilder: (context, child, gravity) {
+        return Positioned(
+          top: MediaQuery.of(context).padding.top,
+          right: 20,
+          left: 20,
+          child: child,
+        );
+      },
+      isDismissible: true,
+    );
+  }
+
+  /// fluttertoast 삭제
+  void dismiss() {
+    if (!_isInitialized) {
+      _init();
+    }
+    _fToast.removeCustomToast();
+  }
+}

--- a/lib/design_system/component/app_snack_bar.dart
+++ b/lib/design_system/component/app_snack_bar.dart
@@ -1,0 +1,130 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/app/asset/assets.gen.dart';
+import 'package:gllo_flutter/app/toast/toast_manager.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/font/app_text_style.dart';
+import 'package:gllo_flutter/design_system/foundation/shadow/app_shadow.dart';
+import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+
+/// Snack Bar
+/// [ToastManager]를 이용하여 제어
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1399-25808&m=dev
+class AppSnackBar extends StatelessWidget {
+  const AppSnackBar({
+    required this.text,
+    required this.action,
+    this.imageUrl,
+    super.key,
+  });
+  final String? imageUrl;
+  final String text;
+  final AppSnackBarAction action;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 72,
+      decoration: BoxDecoration(
+        color: AppScaleColor.white100,
+        borderRadius: BorderRadius.circular(AppLayout.radius300),
+        boxShadow: [AppShadow.shadow12],
+      ),
+      padding: const EdgeInsets.all(AppLayout.marginPaddingS),
+      child: Row(
+        children: [
+          if (imageUrl != null)
+            CachedNetworkImage(
+              imageUrl: imageUrl!,
+              imageBuilder: (context, imageProvider) {
+                return Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(AppLayout.radius200),
+                    image: DecorationImage(
+                      image: imageProvider,
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                );
+              },
+              // TODO: placeholder 수정 예정
+              placeholder:
+                  (context, url) => const CircularProgressIndicator(
+                    color: AppScaleColor.orange500,
+                  ),
+              // TODO: placeholder 수정 예정
+              errorWidget:
+                  (context, url, error) =>
+                      const Icon(Icons.error, color: AppScaleColor.red),
+            ),
+
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.only(left: imageUrl != null ? 8 : 0),
+              child: Text(
+                text,
+                style: AppTextStyle.textSm.copyWith(
+                  color: AppScaleColor.gray600,
+                ),
+                maxLines: 1,
+              ),
+            ),
+          ),
+          action,
+        ],
+      ),
+    );
+  }
+}
+
+/// Snack Bar Action Button
+class AppSnackBarAction extends StatelessWidget {
+  /// action type : undo
+  const AppSnackBarAction.undo({
+    required this.onTap,
+    this.text = 'undo',
+    super.key,
+  }) : type = _AppSnackBarActionType.undo;
+
+  /// action type : close
+  const AppSnackBarAction.close({required this.onTap, super.key})
+    : type = _AppSnackBarActionType.close,
+      text = null;
+
+  // ignore: library_private_types_in_public_api
+  final _AppSnackBarActionType type;
+  final VoidCallback? onTap;
+  final String? text;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.translucent,
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child:
+            type == _AppSnackBarActionType.undo
+                ? Text(
+                  text!,
+                  style: AppTextStyle.textSr.copyWith(color: AppScaleColor.red),
+                )
+                : Assets.icon.system.closeLine.svg(
+                  width: 24,
+                  height: 24,
+                  fit: BoxFit.cover,
+                  colorFilter: const ColorFilter.mode(
+                    AppScaleColor.gray400,
+                    BlendMode.srcIn,
+                  ),
+                ),
+      ),
+    );
+  }
+}
+
+/// Snack Bar Action Button Type
+/// 내부적으로 사용되어서 Private하게 선언
+enum _AppSnackBarActionType { undo, close }

--- a/lib/design_system/component/app_snack_bar.dart
+++ b/lib/design_system/component/app_snack_bar.dart
@@ -89,7 +89,7 @@ class AppSnackBarAction extends StatelessWidget {
   }) : type = _AppSnackBarActionType.undo;
 
   /// action type : close
-  const AppSnackBarAction.close({required this.onTap, super.key})
+  const AppSnackBarAction.close({this.onTap, super.key})
     : type = _AppSnackBarActionType.close,
       text = null;
 
@@ -101,7 +101,11 @@ class AppSnackBarAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: onTap,
+      onTap:
+          onTap ??
+          () {
+            ToastManager().dismiss();
+          },
       behavior: HitTestBehavior.translucent,
       child: Padding(
         padding: const EdgeInsets.all(8),

--- a/lib/design_system/component/app_toast.dart
+++ b/lib/design_system/component/app_toast.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/app/asset/assets.gen.dart';
+import 'package:gllo_flutter/app/toast/toast_manager.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/font/app_text_style.dart';
+import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+
+/// Toast
+/// [ToastManager]를 이용하여 제어
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1399-25359&m=dev
+class AppToast extends StatelessWidget {
+  const AppToast({required this.text, super.key});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 72,
+      padding: const EdgeInsets.all(AppLayout.marginPaddingXl),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppLayout.radius300),
+        color: AppScaleColor.black60,
+      ),
+      child: Row(
+        children: [
+          Assets.icon.quickAction.checkFill.svg(
+            fit: BoxFit.cover,
+            width: 24,
+            height: 24,
+            colorFilter: const ColorFilter.mode(
+              AppScaleColor.gray50,
+              BlendMode.srcIn,
+            ),
+          ),
+          const SizedBox(width: AppLayout.marginPaddingS),
+          Expanded(
+            child: Text(
+              text,
+              style: AppTextStyle.textMm.copyWith(color: AppScaleColor.gray50),
+              maxLines: 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/app.dart
+++ b/lib/presentation/app.dart
@@ -16,6 +16,12 @@ class MyApp extends ConsumerWidget {
         scaffoldBackgroundColor: AppScaleColor.white100,
       ),
       routerConfig: ref.read(appRouterProvider).routerConfig,
+      builder:
+          (context, child) => Overlay(
+            initialEntries: [
+              if (child != null) ...[OverlayEntry(builder: (context) => child)],
+            ],
+          ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -472,6 +472,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      sha256: "25e51620424d92d3db3832464774a6143b5053f15e382d8ffbfd40b6e795dcf1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.12"
   freezed:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   flutter_gen: ^5.10.0
   lottie: ^3.3.1
   smooth_page_indicator: ^1.2.1
+  fluttertoast: ^8.2.12
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📌 관련 이슈
#12 

## ✨ 작업 내용
Snack Bar, Toast를 추가하였습니다.
ToastManager를 이용하여 Snack Bar와 Toast를 제어할 수 있도록 구현하였습니다.
Snack Bar에 Action Button을 추가할때, named constructor를 이용하여 명시적으로 지정할 수 있도록 구현하였습니다.

**Snack Bar 사용**
```dart
/// Action Type : undo
_toastManager.show(
  toastWidget: AppSnackBar(
    text: '스낵바 텍스트',
    action: AppSnackBarAction.undo(
      onTap: () {
        // action
      },
    ),
  ),
);
```

```dart
/// Action Type : close
_toastManager.show(
  toastWidget: AppSnackBar(
    imageUrl: 'https://picsum.photos/250?image=5',
    text: '스낵바 텍스트',
    action: AppSnackBarAction.close(
    ),
  ),
);
```

**Toast 사용**
```dart
_toastManager.show(
  toastWidget: const AppToast(text: '토스트 텍스트')
);
```


## 📸 스크린샷 (선택)
| Snack Bar (action type : undo) | Snack Bar (action type : close) | Snack Bar (with image) | Toast |
| ------------------------------ | ------------------------------ | ----------------------- | ------ |
|  ![Screenshot_1751559933](https://github.com/user-attachments/assets/fe654c38-58f5-42e2-8e51-630176eb6211) |  ![Screenshot_1751560008](https://github.com/user-attachments/assets/5a83cf23-6a21-40d1-beab-ce221c8b97dc) |  ![Screenshot_1751560053](https://github.com/user-attachments/assets/20892725-813c-41fb-ac55-157b8ff16871) |  ![Screenshot_1751560076](https://github.com/user-attachments/assets/22b9faec-69bc-4a6f-8454-588943bc5d40) |





## 📚 참고 자료
<!-- 참고한 가이드 문서나 레퍼런스 링크가 있다면 입력해주세요. -->

