### PR TITLE
[FEAT] Chip, Tag 추가

### DIFF
--- a/lib/design_system/component/app_chip.dart
+++ b/lib/design_system/component/app_chip.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/app/asset/assets.gen.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/font/app_text_style.dart';
+import 'package:gllo_flutter/design_system/foundation/shadow/app_shadow.dart';
+import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+
+/// Chip
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1719-34722&m=dev
+class AppChip extends StatelessWidget {
+  const AppChip.round({
+    super.key,
+    this.icon,
+    required this.text,
+    this.showIcon = false,
+    required this.isSelected,
+    required this.onTap,
+  }) : type = AppChipType.round;
+  const AppChip.rectangular({
+    super.key,
+    this.icon,
+    required this.text,
+    this.showIcon = false,
+    required this.isSelected,
+    required this.onTap,
+  }) : type = AppChipType.rectangular;
+  final SvgGenImage? icon;
+  final String text;
+  final bool showIcon;
+  final bool isSelected;
+  final AppChipType type;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final double height = 44;
+
+    final border = Border.all(
+      color: isSelected ? AppScaleColor.orange500 : AppScaleColor.gray400,
+      width: isSelected ? AppLayout.stroke20 : AppLayout.stroke10,
+    );
+
+    final borderRadius = BorderRadius.circular(
+      type == AppChipType.round ? AppLayout.radius800 : AppLayout.radius300,
+    );
+
+    final backgroundColor =
+        isSelected ? AppScaleColor.orange50 : AppScaleColor.white100;
+
+    final textStyle = AppTextStyle.textMm.copyWith(
+      color: isSelected ? AppScaleColor.orange500 : AppScaleColor.gray700,
+    );
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.translucent,
+      child: Container(
+        height: height,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppLayout.marginPaddingM,
+        ),
+        decoration: BoxDecoration(
+          boxShadow: const [AppShadow.shadow12],
+          borderRadius: borderRadius,
+          border: border,
+          color: backgroundColor,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (showIcon && icon != null)
+              Padding(
+                padding: const EdgeInsets.only(
+                  right: AppLayout.marginPaddingXxs,
+                ),
+                child: icon!.svg(
+                  width: 16,
+                  height: 16,
+                  fit: BoxFit.cover,
+                  colorFilter: const ColorFilter.mode(
+                    AppScaleColor.orange500,
+                    BlendMode.srcIn,
+                  ),
+                ),
+              ),
+            Text(text, style: textStyle),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+enum AppChipType { round, rectangular }

--- a/lib/design_system/component/app_chip.dart
+++ b/lib/design_system/component/app_chip.dart
@@ -12,7 +12,6 @@ class AppChip extends StatelessWidget {
     super.key,
     this.icon,
     required this.text,
-    this.showIcon = false,
     required this.isSelected,
     required this.onTap,
   }) : type = AppChipType.round;
@@ -20,13 +19,11 @@ class AppChip extends StatelessWidget {
     super.key,
     this.icon,
     required this.text,
-    this.showIcon = false,
     required this.isSelected,
     required this.onTap,
   }) : type = AppChipType.rectangular;
   final SvgGenImage? icon;
   final String text;
-  final bool showIcon;
   final bool isSelected;
   final AppChipType type;
   final VoidCallback onTap;
@@ -68,7 +65,7 @@ class AppChip extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (showIcon && icon != null)
+            if (icon != null)
               Padding(
                 padding: const EdgeInsets.only(
                   right: AppLayout.marginPaddingXxs,

--- a/lib/design_system/component/app_tag.dart
+++ b/lib/design_system/component/app_tag.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/font/app_text_style.dart';
+import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+
+/// Tag
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1719-34717&m=dev
+class AppTag extends StatelessWidget {
+  const AppTag.line({super.key, required this.text}) : type = AppTagType.line;
+  const AppTag.bold({super.key, required this.text}) : type = AppTagType.bold;
+
+  final String text;
+  final AppTagType type;
+
+  @override
+  Widget build(BuildContext context) {
+    final padding = const EdgeInsets.symmetric(
+      horizontal: AppLayout.marginPaddingXs,
+      vertical: AppLayout.marginPaddingXxs,
+    );
+
+    final textStyle = AppTextStyle.textSm.copyWith(
+      color:
+          type == AppTagType.line
+              ? AppScaleColor.gray50
+              : AppScaleColor.orange400,
+    );
+
+    final border = Border.all(
+      color:
+          type == AppTagType.line
+              ? AppScaleColor.gray500
+              : AppScaleColor.orange100,
+    );
+
+    final backgroundColor =
+        type == AppTagType.line ? Colors.transparent : AppScaleColor.orange100;
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppLayout.radius200),
+        border: border,
+        color: backgroundColor,
+      ),
+      padding: padding,
+      child: Text(text, style: textStyle),
+    );
+  }
+}
+
+enum AppTagType { line, bold }


### PR DESCRIPTION
## 📌 관련 이슈
#12 
## ✨ 작업 내용
Tag와 Chip을 추가합니다.
Tag는 **line, bold** 이렇게 두개의 타입으로 나뉘며
Chip은 **round, rectangular** 타입으로 나뉩니다.
**named constructor**를 이용하여 명시적으로 타입을 구분하였습니다.

**Tag 사용**
```dart
...
/// Tag type : line
AppTag.line(text: 'Line Tag'),
/// Tag type : bold 
AppTag.bold(text: 'Bold Tag'),
...
```

**Chip 사용**
```dart
...
/// Chip type : round
AppChip.round(
  showIcon: true,
  icon: Assets.icon.quickAction.sendFill,
  text: 'round chip',
  isSelected: _isSelected1,
  onTap: () {
    setState(() {
      _isSelected1 = !_isSelected1;
    });
  },
),
...
/// Chip type : rectangular
AppChip.rectangular(
  // showIcon: true,
  // icon: Assets.icon.quickAction.sendFill,
  text: 'rectangular chip',
  isSelected: _isSelected2,
  onTap: () {
    setState(() {
      _isSelected2 = !_isSelected2;
    });
  },
),
...
```



## 📸 스크린샷 (선택)
| Tag (line, bold)  | Chip (round) | Chip (round, selected) | Chip (rectangular) |
| --------------- | ------------- | ---------------------- | ---------------- |
|  ![Simulator Screenshot - iPhone 16 - 2025-07-07 at 00 11 03](https://github.com/user-attachments/assets/4cb2bbb4-a2f1-499f-ab90-10846d0b4752) |  ![Simulator Screenshot - iPhone 16 - 2025-07-07 at 00 12 20](https://github.com/user-attachments/assets/37d18acf-9990-4d7a-bf18-ea590c2aca3e) |  ![Simulator Screenshot - iPhone 16 - 2025-07-07 at 00 12 22](https://github.com/user-attachments/assets/39a1150f-c70b-4453-a5e7-ba73efadf608) |  ![Simulator Screenshot - iPhone 16 - 2025-07-07 at 00 12 34](https://github.com/user-attachments/assets/93ea6208-0cc1-4b5a-96b5-bcc2f55a1329) |


## 📚 참고 자료
<!-- 참고한 가이드 문서나 레퍼런스 링크가 있다면 입력해주세요. -->

