### PR TITLE
[FEAT] App Text Area Field

### DIFF
--- a/lib/design_system/component/app_text_area_field.dart
+++ b/lib/design_system/component/app_text_area_field.dart
@@ -170,21 +170,22 @@ class _AppTextAreaInternalState extends State<_AppTextAreaInternal> {
               ),
           ],
         ),
-        SizedBox(height: AppLayout.marginPaddingXxs),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(
-            AppLayout.marginPaddingXs,
-            5,
-            AppLayout.marginPaddingXs,
-            5,
-          ),
-          child: Text(
-            widget.errorText ?? widget.helpMessage ?? '',
-            style: AppTextStyle.textSr.copyWith(
-              color: isError ? AppScaleColor.red : AppScaleColor.gray500,
+        const SizedBox(height: AppLayout.marginPaddingXxs),
+        if (widget.errorText != null || widget.helpMessage != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppLayout.marginPaddingXs,
+              5,
+              AppLayout.marginPaddingXs,
+              5,
+            ),
+            child: Text(
+              widget.errorText ?? widget.helpMessage ?? '',
+              style: AppTextStyle.textSr.copyWith(
+                color: isError ? AppScaleColor.red : AppScaleColor.gray500,
+              ),
             ),
           ),
-        ),
       ],
     );
   }

--- a/lib/design_system/component/app_text_area_field.dart
+++ b/lib/design_system/component/app_text_area_field.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:gllo_flutter/app/asset/assets.gen.dart';
 import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
 import 'package:gllo_flutter/design_system/foundation/font/app_text_style.dart';
 import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
@@ -20,7 +19,7 @@ class AppTextAreaField extends FormField<String> {
   }) : super(
          initialValue: controller.text,
          enabled: isEnabled,
-         builder: (FormFieldState<String> field) {
+         builder: (field) {
            return _AppTextAreaInternal(
              label: label,
              controller: controller,
@@ -127,6 +126,7 @@ class _AppTextAreaInternalState extends State<_AppTextAreaInternal> {
         Stack(
           children: [
             TextField(
+              onTapOutside: (event) => FocusScope.of(context).unfocus(),
               controller: widget.controller,
               enabled: widget.isEnabled,
               maxLength: widget.maxLength,

--- a/lib/design_system/component/app_text_area_field.dart
+++ b/lib/design_system/component/app_text_area_field.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/app/asset/assets.gen.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/font/app_text_style.dart';
+import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+
+class AppTextAreaField extends FormField<String> {
+  AppTextAreaField({
+    super.key,
+    super.validator,
+    required this.label,
+    required this.controller,
+    required this.placeholder,
+    this.isEnabled = true,
+    this.maxLength,
+    this.maxLines = 4,
+    this.helpMessage,
+    this.onChanged,
+    this.suffix,
+  }) : super(
+         initialValue: controller.text,
+         enabled: isEnabled,
+         builder: (FormFieldState<String> field) {
+           return _AppTextAreaInternal(
+             label: label,
+             controller: controller,
+             placeholder: placeholder,
+             isEnabled: isEnabled,
+             errorText: field.errorText,
+             helpMessage: helpMessage,
+             maxLength: maxLength,
+             maxLines: maxLines,
+             onChanged: (value) {
+               field.didChange(value);
+               onChanged?.call(value);
+             },
+             suffix: suffix,
+           );
+         },
+       );
+
+  final String label;
+  final TextEditingController controller;
+  final String placeholder;
+  final bool isEnabled;
+  final int? maxLength;
+  final int maxLines;
+  final String? helpMessage;
+  final ValueChanged<String>? onChanged;
+  final Widget? suffix;
+}
+
+class _AppTextAreaInternal extends StatefulWidget {
+  const _AppTextAreaInternal({
+    required this.label,
+    required this.controller,
+    required this.placeholder,
+    required this.isEnabled,
+    required this.errorText,
+    required this.onChanged,
+    required this.maxLength,
+    required this.maxLines,
+    this.helpMessage,
+    this.suffix,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final String placeholder;
+  final bool isEnabled;
+  final String? errorText;
+  final String? helpMessage;
+  final int? maxLength;
+  final int maxLines;
+  final ValueChanged<String> onChanged;
+  final Widget? suffix;
+
+  @override
+  State<_AppTextAreaInternal> createState() => _AppTextAreaInternalState();
+}
+
+class _AppTextAreaInternalState extends State<_AppTextAreaInternal> {
+  OutlineInputBorder border(Color color) => OutlineInputBorder(
+    borderRadius: BorderRadius.circular(AppLayout.radius300),
+    borderSide: BorderSide(color: color, width: AppLayout.stroke15),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(() {
+      setState(() {});
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isError = widget.errorText != null;
+    final hasNoInput = widget.controller.text.isEmpty;
+
+    final borderColor =
+        isError
+            ? AppScaleColor.red
+            : !widget.isEnabled
+            ? AppScaleColor.gray200
+            : hasNoInput
+            ? AppScaleColor.gray50
+            : AppScaleColor.gray500;
+
+    final currentLength = widget.controller.text.length;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppLayout.marginPaddingXs,
+          ),
+          child: Text(
+            widget.label,
+            style: AppTextStyle.textMm.copyWith(
+              color: isError ? AppScaleColor.red : AppScaleColor.gray800,
+            ),
+          ),
+        ),
+        const SizedBox(height: AppLayout.marginPaddingXxs),
+        Stack(
+          children: [
+            TextField(
+              controller: widget.controller,
+              enabled: widget.isEnabled,
+              maxLength: widget.maxLength,
+              maxLines: widget.maxLines,
+              style: AppTextStyle.textMm.copyWith(color: AppScaleColor.gray800),
+              onChanged: widget.onChanged,
+              decoration: InputDecoration(
+                filled: true,
+                fillColor:
+                    widget.isEnabled
+                        ? AppScaleColor.gray50
+                        : Colors.grey.shade100,
+                hintText: widget.placeholder,
+                hintStyle: AppTextStyle.textMm.copyWith(
+                  color: AppScaleColor.gray400,
+                ),
+                counterText: '',
+                // 기본 카운터 제거
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: AppLayout.marginPaddingM,
+                  vertical: AppLayout.marginPaddingM,
+                ),
+                border: border(borderColor),
+                enabledBorder: border(borderColor),
+                focusedBorder: border(borderColor),
+                disabledBorder: border(borderColor),
+                errorBorder: border(AppScaleColor.red),
+                suffixIcon: widget.suffix,
+              ),
+            ),
+            if (widget.maxLength != null)
+              Positioned(
+                bottom: 16,
+                right: 16,
+                child: Text(
+                  '$currentLength/${widget.maxLength}',
+                  style: AppTextStyle.textSr.copyWith(
+                    color: AppScaleColor.gray400,
+                  ),
+                ),
+              ),
+          ],
+        ),
+        SizedBox(height: AppLayout.marginPaddingXxs),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppLayout.marginPaddingXs,
+            5,
+            AppLayout.marginPaddingXs,
+            5,
+          ),
+          child: Text(
+            widget.errorText ?? widget.helpMessage ?? '',
+            style: AppTextStyle.textSr.copyWith(
+              color: isError ? AppScaleColor.red : AppScaleColor.gray500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈 번호를 입력해주세요. 예: #123 -->
#12 

## ✨ 작업 내용
<!-- 변경 사항을 간략히 요약해주세요.
   - 무엇을 변경했는지
   - 왜 변경했는지 -->
   AppTextAreaField도 FormField 위젯으로 텍스트 유효성 검사, 상태에 따른 스타일 변경, 입력값 카운팅이 가능하도록 구현했습니다.

#### _AppTextAreaInternal extends StatefulWidget
- 텍스트 입력에 따른 실시간 UI 반영(글자 수, border)을 위해 StatefulWidget 사용

#### 폼 유효성 검사와 연동되도록 FormField를 상속
- validator를 통해 폼 전반의 유효성 검사 처리 가능
- Form 위젯 내에서 .validate() 호출 시 이 위젯도 검증됨

## 📸 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 첨부해주세요. -->
| TextAreaField-default |  TextAreaField-typing | 
| ----------------------------------- | -------------------------------------- | 
|  ![IMG_7306](https://github.com/user-attachments/assets/d92ef4fd-116c-4a70-8857-04e39b86eb98) | ![IMG_7307](https://github.com/user-attachments/assets/69603476-bb52-4267-8859-f6b2be2fc1a8) | 

## 📚 참고 자료
<!-- 참고한 가이드 문서나 레퍼런스 링크가 있다면 입력해주세요. -->

