### PR TITLE
[FEAT] App Gradient Overlay 추가

### DIFF
--- a/lib/design_system/component/app_gradient_overlay.dart
+++ b/lib/design_system/component/app_gradient_overlay.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class AppGradientOverlay extends StatelessWidget {
+  const AppGradientOverlay({
+    super.key,
+    this.height,
+    this.width,
+    this.borderRadius,
+    this.begin = Alignment.topCenter,
+    this.end = Alignment.bottomCenter,
+    this.colors,
+  });
+
+  final double? height;
+  final double? width;
+  final BorderRadius? borderRadius;
+
+  final Alignment begin;
+  final Alignment end;
+
+  final List<Color>? colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      width: width,
+      decoration: BoxDecoration(
+        borderRadius: borderRadius,
+        gradient: LinearGradient(
+          begin: begin,
+          end: end,
+          colors: colors ?? const [Colors.white, Colors.black],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈 번호를 입력해주세요. 예: #123 -->
#12 

## ✨ 작업 내용
<!-- 변경 사항을 간략히 요약해주세요.
   - 무엇을 변경했는지
   - 왜 변경했는지 -->
  - 지정된 영역에 LinearGradient를 적용할 수 있는 Gradient Overlay를 구현했습니다.
  

```dart
GradientOverlay(
    height: 100,
    width: 100,
),
GradientOverlay(
    height: 300,
    width: 300,
    borderRadius: BorderRadius.all(Radius.circular(12)),
    colors: [
        AppScaleColor.white100,
        AppScaleColor.black100,
    ],
),
```

크기만 지정해도 되고, radius 를 추가하거나 컬러도 재지정 가능합니다!
그리고 이미지 위에 Stack으로 쌓아서 사용하면 됩니다!!

## 📸 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 첨부해주세요. -->
![IMG_7315](https://github.com/user-attachments/assets/600a0d22-fa93-4a2d-bfc3-495a5c2ec36e)


## 📚 참고 자료
<!-- 참고한 가이드 문서나 레퍼런스 링크가 있다면 입력해주세요. -->

