### PR TITLE
[FEAT] Bottom Sheet 추가

### DIFF
--- a/lib/design_system/component/app_bottom_sheet.dart
+++ b/lib/design_system/component/app_bottom_sheet.dart
@@ -7,6 +7,7 @@ import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
 import 'package:go_router/go_router.dart';
 
 /// Bottom Sheet (기본형)
+/// [showAppBottomSheet]를 이용
 /// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1792-31668&m=dev
 class AppBottomSheet extends StatelessWidget {
   const AppBottomSheet({

--- a/lib/design_system/component/app_bottom_sheet.dart
+++ b/lib/design_system/component/app_bottom_sheet.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:gllo_flutter/design_system/component/app_button.dart';
+import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+
+/// Bottom Sheet (기본형)
+/// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1792-31668&m=dev
+class AppBottomSheet extends StatelessWidget {
+  const AppBottomSheet({
+    required this.child,
+    this.height,
+    this.button,
+    super.key,
+  });
+  final Widget child; // 바텀 시트 컨텐츠 영역.
+  final double? height; // 바텀 시트 전체 높이. 전체 화면을 덮는 바텀시트를 생성하려면 double.infinity 지정
+  final AppBottomSheetButton? button; // 바텀 시트 버튼.
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    return Container(
+      width: size.width,
+      height: height ?? size.height * 400 / 844,
+      decoration: BoxDecoration(
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(AppLayout.radius400),
+          topRight: Radius.circular(AppLayout.radius400),
+        ),
+        color: AppScaleColor.white100,
+      ),
+      child: Column(
+        children: [
+          SizedBox(
+            height: 18,
+            child: Center(
+              child: Container(
+                width: 36,
+                height: 5,
+                decoration: ShapeDecoration(
+                  color: const Color(0x7F3D3D3D),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(2.50),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Expanded(child: child),
+          if (button != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+              child: SizedBox(
+                width: double.infinity,
+                child: AppButton(
+                  size: AppButtonSize.large,
+                  style: AppButtonStyle.primary,
+                  label: button!.text,
+                  onPressed: button!.onTap,
+                ),
+              ),
+            ),
+          SizedBox(height: MediaQuery.of(context).padding.bottom),
+        ],
+      ),
+    );
+  }
+}
+
+/// App Bottom Sheet 내 Button 자료구조
+class AppBottomSheetButton {
+  const AppBottomSheetButton({required this.text, required this.onTap});
+  final String text;
+  final VoidCallback onTap;
+}
+
+/// App Bottom Sheet 표시
+void showAppBottomSheet({
+  required BuildContext context,
+  required Widget Function(BuildContext) builder,
+}) {
+  showModalBottomSheet(
+    isScrollControlled: true,
+    useSafeArea: true,
+    context: context,
+    builder: builder,
+  );
+}

--- a/lib/design_system/component/app_bottom_sheet.dart
+++ b/lib/design_system/component/app_bottom_sheet.dart
@@ -1,17 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:gllo_flutter/app/asset/assets.gen.dart';
 import 'package:gllo_flutter/design_system/component/app_button.dart';
 import 'package:gllo_flutter/design_system/foundation/color/app_color.dart';
+import 'package:gllo_flutter/design_system/foundation/font/app_text_style.dart';
 import 'package:gllo_flutter/design_system/foundation/size/app_layout.dart';
+import 'package:go_router/go_router.dart';
 
 /// Bottom Sheet (기본형)
 /// https://www.figma.com/design/i2Rdv9uaE5bQ1TTasEKoNN/GllO-%EC%9E%91%EC%97%85-%EB%AC%B8%EC%84%9C-v1.0?node-id=1792-31668&m=dev
 class AppBottomSheet extends StatelessWidget {
   const AppBottomSheet({
     required this.child,
+    this.header,
     this.height,
     this.button,
     super.key,
   });
+  final AppBottomSheetHeader? header; // 바텀 시트 헤더.
   final Widget child; // 바텀 시트 컨텐츠 영역.
   final double? height; // 바텀 시트 전체 높이. 전체 화면을 덮는 바텀시트를 생성하려면 double.infinity 지정
   final AppBottomSheetButton? button; // 바텀 시트 버튼.
@@ -31,37 +36,84 @@ class AppBottomSheet extends StatelessWidget {
       ),
       child: Column(
         children: [
-          SizedBox(
-            height: 18,
-            child: Center(
-              child: Container(
-                width: 36,
-                height: 5,
-                decoration: ShapeDecoration(
-                  color: const Color(0x7F3D3D3D),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(2.50),
-                  ),
-                ),
+          _buildHandleBar(),
+          if (header != null) _buildHeader(context),
+          Expanded(child: child),
+          if (button != null) _buildButton(),
+          SizedBox(height: MediaQuery.of(context).padding.bottom),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHandleBar() {
+    return SizedBox(
+      height: 18,
+      child: Center(
+        child: Container(
+          width: 36,
+          height: 5,
+          decoration: ShapeDecoration(
+            color: const Color(0x7F3D3D3D),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(2.50),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Container(
+      height: 55,
+      padding: const EdgeInsets.fromLTRB(
+        AppLayout.marginPaddingL,
+        AppLayout.marginPaddingXxs,
+        AppLayout.marginPaddingS,
+        AppLayout.marginPaddingL - 1,
+      ),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: AppScaleColor.gray300)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              header!.text,
+              style: AppTextStyle.titleS.copyWith(color: AppScaleColor.gray800),
+            ),
+          ),
+          GestureDetector(
+            onTap: () {
+              context.pop();
+            },
+            child: Assets.icon.system.closeLine.svg(
+              width: 24,
+              height: 24,
+              fit: BoxFit.cover,
+              colorFilter: const ColorFilter.mode(
+                AppScaleColor.gray800,
+                BlendMode.srcIn,
               ),
             ),
           ),
-          Expanded(child: child),
-          if (button != null)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
-              child: SizedBox(
-                width: double.infinity,
-                child: AppButton(
-                  size: AppButtonSize.large,
-                  style: AppButtonStyle.primary,
-                  label: button!.text,
-                  onPressed: button!.onTap,
-                ),
-              ),
-            ),
-          SizedBox(height: MediaQuery.of(context).padding.bottom),
         ],
+      ),
+    );
+  }
+
+  Widget _buildButton() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+      child: SizedBox(
+        width: double.infinity,
+        child: AppButton(
+          size: AppButtonSize.large,
+          style: AppButtonStyle.primary,
+          label: button!.text,
+          onPressed: button!.onTap,
+        ),
       ),
     );
   }
@@ -72,6 +124,12 @@ class AppBottomSheetButton {
   const AppBottomSheetButton({required this.text, required this.onTap});
   final String text;
   final VoidCallback onTap;
+}
+
+/// App Bottom Sheet 내 Header 자료구조
+class AppBottomSheetHeader {
+  const AppBottomSheetHeader({required this.text});
+  final String text;
 }
 
 /// App Bottom Sheet 표시

--- a/lib/design_system/component/app_button.dart
+++ b/lib/design_system/component/app_button.dart
@@ -37,11 +37,12 @@ class AppButton extends StatelessWidget {
           AppButtonSize.large: 52.0,
         }[size]!;
 
-    final textStyle = {
-      AppButtonSize.small: AppTextStyle.textSm,
-      AppButtonSize.medium: AppTextStyle.textMm,
-      AppButtonSize.large: AppTextStyle.textMm,
-    }[size]!;
+    final textStyle =
+        {
+          AppButtonSize.small: AppTextStyle.textSm,
+          AppButtonSize.medium: AppTextStyle.textMm,
+          AppButtonSize.large: AppTextStyle.textMm,
+        }[size]!;
 
     const padding = EdgeInsets.symmetric(
       horizontal: AppLayout.marginPaddingM,
@@ -71,7 +72,8 @@ class AppButton extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           if (showIcon && icon != null) _buildIcon(),
-          if (showIcon && showText) const SizedBox(width: AppLayout.marginPaddingXxs),
+          if (showIcon && showText)
+            const SizedBox(width: AppLayout.marginPaddingXxs),
           if (showText) Text(label, style: textStyle),
         ],
       ),


### PR DESCRIPTION
## 📌 관련 이슈
#12 

## ✨ 작업 내용
Bottom Sheet를 추가하였습니다. 
저희 Bottom Sheet는 Header area, Content area, Button area를 갖고 있는데요,
이중 Header area, Button area는 Optional 합니다.

Bottom Sheet의 속성은 아래와 같습니다.

| Property | Description |
| ------- | ------------- |
| header | 헤더 (optional) |
| child | 컨텐츠 (required) |
| button | 하단 버튼 (optional) |
| height | 바텀시트 높이 (기본값은 화면의 절반 높이) |

```dart
showAppBottomSheet(
  context: context,
  builder: (context) {
    return AppBottomSheet(
      header: const AppBottomSheetHeader(text: '바텀시트 헤더'),
      button: AppBottomSheetButton(
        text: '바텀시트 버튼',
        onTap: () {
          // action
        },
      ),
     /// 확장된 바텀시트를 만드려면 이렇게  height에 double.infinity를 지정합니다.
      height: double.infinity,
     /// child에 이렇게 Scrollable한 위젯을 지정할 수도 있습니다
      child: SingleChildScrollView(
        child: Column(
          children: [
            ///
          ],
        ),
      ),
    );
  },
);
```

## 📸 스크린샷 (선택)
| 바텀시트 (only content) | 바텀시트 (content, button) | 바텀 시트 (content, button, expanded mode) |
| -------------------------- | ------------------------------ | ------------------------------------------------- |
|  ![Simulator Screenshot - iPhone 16 - 2025-07-10 at 01 04 06](https://github.com/user-attachments/assets/2cc97b44-019b-479f-bb33-8cbce8a11bc8) |  ![Simulator Screenshot - iPhone 16 - 2025-07-10 at 01 04 20](https://github.com/user-attachments/assets/d1c6fd44-22e0-4910-85c4-c5219a4b3ea8) |  ![Simulator Screenshot - iPhone 16 - 2025-07-10 at 01 04 45](https://github.com/user-attachments/assets/976ee1bf-c82b-4f83-8ecd-f02cb19aeabd) |

| 바텀시트 (header, content) | 바텀시트 (header, content, button) | 바텀시트 (header, content, button, expanded mode) |
| ------------------------ | ---------------------------------- | -------------------------------------------------- |
| ![Simulator Screenshot - iPhone 16 - 2025-07-10 at 01 22 33](https://github.com/user-attachments/assets/fb01b273-261a-43f4-a9fc-96f07c9fc9d3) |  ![Simulator Screenshot - iPhone 16 - 2025-07-10 at 01 22 41](https://github.com/user-attachments/assets/d2bd1746-e70a-446b-aa4c-8dd42231ac3a) |  ![Simulator Screenshot - iPhone 16 - 2025-07-10 at 01 23 19](https://github.com/user-attachments/assets/c0e7951e-5153-4a95-bd29-1f13fd80331c) |


바텀시트 내 Scrollable Widget은 다음과 같이 동작합니다
https://github.com/user-attachments/assets/e77eab1a-afe3-4a62-a7c7-650229a8f902






## 📚 참고 자료

